### PR TITLE
Fix for "'tuple' object is not callable" when using --digest flag

### DIFF
--- a/carddav.py
+++ b/carddav.py
@@ -108,7 +108,8 @@ class PyCardDAV(object):
         if auth == 'basic':
             self._settings['auth'] = (user, passwd,)
         if auth == 'digest':
-            self._settings['auth'] = ('digest', user, passwd)
+            from requests.auth import HTTPDigestAuth
+            self._settings['auth'] = HTTPDigestAuth(user, passwd)
         self._default_headers = {"User-Agent": "pyCardDAV"}
         response = self.session.request('PROPFIND', resource,
                                         headers=self.headers,


### PR DESCRIPTION
I was having issues when using the --digest flag, using this code fixed it.
