### PR TITLE
fix download from ownCloud (SabreDAV) servers

### DIFF
--- a/carddav.py
+++ b/carddav.py
@@ -292,6 +292,7 @@ class PyCardDAV(object):
                         for props in prop.iterchildren():
                             if (props.tag == namespace + "getcontenttype" and
                                 (props.text == "text/vcard" or
+                                 props.text == "text/vcard; charset=utf-8" or
                                  props.text == "text/x-vcard" or
                                  props.text == "text/x-vcard; charset=utf-8")):
                                 insert = True


### PR DESCRIPTION
also accept vcards with the property "text/vcard; charset=utf-8", this is needed in order to work correctly with ownCloud (SabreDAV)